### PR TITLE
Add langoustine to the existing list of schedulers.

### DIFF
--- a/app-conf/SchedulerConf.xml
+++ b/app-conf/SchedulerConf.xml
@@ -41,11 +41,7 @@
     <scheduler>
         <name>langoustine</name>
         <classname>com.linkedin.drelephant.schedulers.LangoustineScheduler</classname>
-        <params>
-            <bidata>datamart</bidata>
-            <bicore>datamart-core</bicore>
-            <!--<user>add new langoustine flow here</user>-->
-        </params>
+        <params></params>
 
     </scheduler>
 

--- a/app-conf/SchedulerConf.xml
+++ b/app-conf/SchedulerConf.xml
@@ -39,6 +39,17 @@
     </scheduler>
 
     <scheduler>
+        <name>langoustine</name>
+        <classname>com.linkedin.drelephant.schedulers.LangoustineScheduler</classname>
+        <params>
+            <bidata>datamart</bidata>
+            <bicore>datamart-core</bicore>
+            <!--<user>add new langoustine flow here</user>-->
+        </params>
+
+    </scheduler>
+
+    <scheduler>
         <name>oozie</name>
         <classname>com.linkedin.drelephant.schedulers.OozieScheduler</classname>
         <params>

--- a/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.drelephant.schedulers;
+
+import com.linkedin.drelephant.configurations.scheduler.SchedulerConfigurationData;
+import org.apache.log4j.Logger;
+
+import java.util.Properties;
+
+
+/**
+ * This class provides methods to load information specific to the Langoustine scheduler.
+ */
+public class LangoustineScheduler implements Scheduler {
+
+  private static final Logger logger = Logger.getLogger(LangoustineScheduler.class);
+
+  public static final String LANGOUSTINE_JOB_ID = "com.criteo.langoustine.name";
+  public static final String LANGOUSTINE_START_DATE = "com.criteo.langoustine.calc_start";
+
+  private String schedulerName;
+  private String jobId;
+  private String jobDate;
+  private String jobWorkflow;
+  private String jobName;
+
+  private String jobDefUrl   = ""; // TODO
+  private String jobExecUrl  = ""; // TODO
+  private String flowDefUrl  = ""; // TODO
+  private String flowExecUrl = ""; // TODO
+
+
+  public LangoustineScheduler(String appId, Properties properties, SchedulerConfigurationData schedulerConfData) {
+
+    String maybeWorkflow = schedulerConfData.getParamMap().get(properties.getProperty("userName"));
+    if (maybeWorkflow == null) {
+      jobWorkflow = "all";
+    } else {
+      jobWorkflow = maybeWorkflow;
+    }
+
+    schedulerName = schedulerConfData.getSchedulerName();
+    if (properties != null) {
+      loadInfo(appId, properties);
+    } else {
+      // Use default value of data type
+    }
+  }
+
+  private void loadInfo(String appId, Properties properties) {
+    jobId = properties.getProperty(LANGOUSTINE_JOB_ID);
+    jobDate = properties.getProperty(LANGOUSTINE_START_DATE);
+    jobName = jobId;
+  }
+
+  @Override
+  public String getSchedulerName() {
+    return schedulerName;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    boolean result = jobId == null || jobDate == null || jobWorkflow == null;
+    return result;
+  }
+
+  @Override
+  public String getJobDefId() {
+    return jobId;
+  }
+
+  @Override
+  public String getJobExecId() {
+    return jobId + "_" + jobDate;
+  }
+
+  @Override
+  public String getFlowDefId() {
+    return jobWorkflow;
+  }
+
+  @Override
+  public String getFlowExecId() {
+      return jobDate;
+  }
+
+  @Override
+  public String getJobDefUrl() {
+    return jobDefUrl;
+  }
+
+  @Override
+  public String getJobExecUrl() {
+    return jobExecUrl;
+  }
+
+  @Override
+  public String getFlowDefUrl() {
+    return flowDefUrl;
+  }
+
+  @Override
+  public String getFlowExecUrl() {
+    return flowExecUrl;
+  }
+
+  @Override
+  public int getWorkflowDepth() {
+    return 0;
+  } // TODO
+
+  @Override
+  public String getJobName() {
+    return jobName;
+  }
+}

--- a/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
@@ -74,8 +74,7 @@ public class LangoustineScheduler implements Scheduler {
 
   @Override
   public boolean isEmpty() {
-    boolean result = jobId == null || jobDate == null || jobWorkflow == null;
-    return result;
+    return jobId == null || jobDate == null || jobWorkflow == null;
   }
 
   @Override

--- a/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
+++ b/app/com/linkedin/drelephant/schedulers/LangoustineScheduler.java
@@ -31,6 +31,7 @@ public class LangoustineScheduler implements Scheduler {
 
   public static final String LANGOUSTINE_JOB_ID = "com.criteo.langoustine.name";
   public static final String LANGOUSTINE_START_DATE = "com.criteo.langoustine.calc_start";
+  public static final String LANGOUSTINE_PROJECT_NAME = "com.criteo.langoustine.project_name";
 
   private String schedulerName;
   private String jobId;
@@ -46,12 +47,13 @@ public class LangoustineScheduler implements Scheduler {
 
   public LangoustineScheduler(String appId, Properties properties, SchedulerConfigurationData schedulerConfData) {
 
-    String maybeWorkflow = schedulerConfData.getParamMap().get(properties.getProperty("userName"));
+    String maybeWorkflow = properties.getProperty(LANGOUSTINE_PROJECT_NAME);
     if (maybeWorkflow == null) {
-      jobWorkflow = "all";
+      jobWorkflow = "default_langoustine";
     } else {
       jobWorkflow = maybeWorkflow;
     }
+    logger.info("Langoustine project name for application " + appId + "is : " + jobWorkflow);
 
     schedulerName = schedulerConfData.getSchedulerName();
     if (properties != null) {
@@ -93,9 +95,7 @@ public class LangoustineScheduler implements Scheduler {
   }
 
   @Override
-  public String getFlowExecId() {
-      return jobDate;
-  }
+  public String getFlowExecId() { return jobDate; }
 
   @Override
   public String getJobDefUrl() {

--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -117,12 +117,6 @@ public class InfoExtractor {
       properties = retrieveSparkProperties((SparkApplicationData) data);
     }
 
-    // TODO temporary fix, it should be automatically set by langoustine in the /conf properties
-    logger.info("Adding user " + result.username + " to the properties");
-    if (result != null && result.username != null) {
-      properties.setProperty("userName", result.username);
-    }
-
     Scheduler scheduler = getSchedulerInstance(data.getAppId(), properties);
 
     if (scheduler == null) {

--- a/app/com/linkedin/drelephant/util/InfoExtractor.java
+++ b/app/com/linkedin/drelephant/util/InfoExtractor.java
@@ -116,6 +116,13 @@ public class InfoExtractor {
     } else if ( data instanceof SparkApplicationData) {
       properties = retrieveSparkProperties((SparkApplicationData) data);
     }
+
+    // TODO temporary fix, it should be automatically set by langoustine in the /conf properties
+    logger.info("Adding user " + result.username + " to the properties");
+    if (result != null && result.username != null) {
+      properties.setProperty("userName", result.username);
+    }
+
     Scheduler scheduler = getSchedulerInstance(data.getAppId(), properties);
 
     if (scheduler == null) {

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -1516,7 +1516,7 @@ public class Application extends Controller {
   private static long getFlowTime(AppResult mrJob) {
     long flowTime;
 
-    if ( !mrJob.scheduler.equals("langoustine") ) {
+    if ( mrJob.scheduler == null || !mrJob.scheduler.equals("langoustine") ) {
       flowTime = mrJob.finishTime;
     } else {
       try {

--- a/app/views/page/flowHistoryPage.scala.html
+++ b/app/views/page/flowHistoryPage.scala.html
@@ -26,7 +26,7 @@
     <form class="box" id="flow-history-form" role="form" method="get" action="@routes.Application.flowHistory()">
       <div class="form-group">
         <label for="form-flow-def-idurl" >Flow Definition URL/ID</label>
-        <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value=@flowDefId>
+        <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value="@flowDefId">
       </div>
       <label for="graphType">Filter</label>
       <table>

--- a/app/views/page/oldFlowHistoryPage.scala.html
+++ b/app/views/page/oldFlowHistoryPage.scala.html
@@ -24,7 +24,7 @@
       <form id="flow-history-form" role="form" method="get" action="@routes.Application.oldFlowHistory()">
         <div class="form-group">
           <label for="form-flow-def-idurl">Flow Definition URL/ID</label>
-          <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value=@flowDefId>
+          <input type="text" class="form-control" id="form-flow-def-id" name="flow-def-id" placeholder="Flow Definition URL/ID" value="@flowDefId">
         </div>
         <label for="graphType">Filter</label>
         <select class="form-control" name="select-graph-type" id="graphType">

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,9 @@ organization := "com.linkedin.drelephant"
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
 
+// Prevent failure on some environment
+javaOptions in (Test) ++= Seq("-Duser.country=US", "-Duser.language=en")
+
 libraryDependencies ++= dependencies map { _.excludeAll(exclusionRules: _*) }
 
 // Create a new custom configuration called compileonly

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -218,14 +218,14 @@ public class InfoExtractorTest {
     InfoExtractor.loadSchedulerInfo(result, data, scheduler);
 
     assertEquals(result.scheduler, "azkaban");
-    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
-    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
-    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
-    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
-    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
-    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
-    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
-    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
+    assertFalse(StringUtils.isEmpty(result.jobExecId));
+    assertFalse(StringUtils.isEmpty(result.jobDefId));
+    assertFalse(StringUtils.isEmpty(result.flowExecId));
+    assertFalse(StringUtils.isEmpty(result.flowDefId));
+    assertFalse(StringUtils.isEmpty(result.jobExecUrl));
+    assertFalse(StringUtils.isEmpty(result.jobDefUrl));
+    assertFalse(StringUtils.isEmpty(result.flowExecUrl));
+    assertFalse(StringUtils.isEmpty(result.flowDefUrl));
   }
 
   @Test

--- a/test/com/linkedin/drelephant/util/InfoExtractorTest.java
+++ b/test/com/linkedin/drelephant/util/InfoExtractorTest.java
@@ -218,14 +218,14 @@ public class InfoExtractorTest {
     InfoExtractor.loadSchedulerInfo(result, data, scheduler);
 
     assertEquals(result.scheduler, "azkaban");
-    assertFalse(StringUtils.isEmpty(result.jobExecId));
-    assertFalse(StringUtils.isEmpty(result.jobDefId));
-    assertFalse(StringUtils.isEmpty(result.flowExecId));
-    assertFalse(StringUtils.isEmpty(result.flowDefId));
-    assertFalse(StringUtils.isEmpty(result.jobExecUrl));
-    assertFalse(StringUtils.isEmpty(result.jobDefUrl));
-    assertFalse(StringUtils.isEmpty(result.flowExecUrl));
-    assertFalse(StringUtils.isEmpty(result.flowDefUrl));
+    assertFalse(StringUtils.isEmpty(result.getJobExecId()));
+    assertFalse(StringUtils.isEmpty(result.getJobDefId()));
+    assertFalse(StringUtils.isEmpty(result.getFlowExecId()));
+    assertFalse(StringUtils.isEmpty(result.getFlowDefId()));
+    assertFalse(StringUtils.isEmpty(result.getJobExecUrl()));
+    assertFalse(StringUtils.isEmpty(result.getJobDefUrl()));
+    assertFalse(StringUtils.isEmpty(result.getFlowExecUrl()));
+    assertFalse(StringUtils.isEmpty(result.getFlowDefUrl()));
   }
 
   @Test


### PR DESCRIPTION
This adds langoustine to the list of schedulers already integrated to Dr.Elephant. It will most notably allow the "flow history" and "job history" view to work with jobs scheduled with langoustine.

As Langoustine concepts are a bit different than the other schedulers, some changes were needed and it was not as simple as simply adding a new scheduler class. More particularly, we do not have a concept of "flow" or "flow execution id" in Langoustine. The work-around here is to consider the flow as the langoustine project itself (e.g. datamart, product-rollout, etc.), while the flow execution id is the langoustine start date, i.e. the langoustine functional date (which should always correspond to a specific rounded hour, e.g. Jun 19, 2017 04:00 PM).

However, Langoustine currently does not log the project name, and the tempory fix is to use the scheduler configuration file, to map the user name to a specific project name. Users not mapped to a specific project are currently mapped to "all", so that the related jobs can still be viewed in the flow/job history views.

Finally, there is still some integration to do, in a subsequent PR, as some urls are not refered yet. This means that some links between the different views are not working properly, however, there is no regression compared to the previous status, as the views were not even available for langoustine jobs.