### PR TITLE
Add custom flowtime per scheduler

### DIFF
--- a/app-conf/SchedulerConf.xml
+++ b/app-conf/SchedulerConf.xml
@@ -34,6 +34,8 @@
           <!--<private_key>/home/key/private_key</private_key>-->
           <!--<userame>elephant</userame>-->
           <!--<password></password>-->
+          <!--<flowtimefield>flowExecId</flowtimefield>-->
+          <!--<flowtimetype>yyyy-MM-dd'T'HH:mm:ss</flowtimetype>-->
         </params>
 
     </scheduler>

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -457,7 +457,7 @@ public class Application extends Controller {
    * @return A map of Job Urls to the list of jobs corresponding to the 2 flow execution urls
    */
   private static Map<IdUrlPair, Map<IdUrlPair, List<AppResult>>> compareFlows(List<AppResult> results1, List<AppResult> results2) {
-    
+
     Map<IdUrlPair, Map<IdUrlPair, List<AppResult>>> jobDefMap = new HashMap<IdUrlPair, Map<IdUrlPair, List<AppResult>>>();
 
     if (results1 != null && !results1.isEmpty() && results2 != null && !results2.isEmpty()) {
@@ -1137,15 +1137,19 @@ public class Application extends Controller {
 
       // Execution record
       JsonObject dataset = new JsonObject();
-      dataset.addProperty("flowtime", mrJobsList.get(mrJobsList.size() - 1).finishTime);
+      dataset.addProperty("flowtime", Utils.getFlowTime(mrJobsList.get(mrJobsList.size() - 1)));
       dataset.addProperty("score", flowPerfScore);
       dataset.add("jobscores", jobScores);
 
       datasets.add(dataset);
     }
 
-    return ok(new Gson().toJson(datasets));
+    JsonArray sortedDatasets = Utils.sortJsonArray(datasets);
+
+    return ok(new Gson().toJson(sortedDatasets));
   }
+
+
 
   /**
    * The data for plotting the job history graph. While plotting the job history
@@ -1228,14 +1232,16 @@ public class Application extends Controller {
 
       // Execution record
       JsonObject dataset = new JsonObject();
-      dataset.addProperty("flowtime", mrJobsList.get(mrJobsList.size() - 1).finishTime);
+      dataset.addProperty("flowtime", Utils.getFlowTime(mrJobsList.get(mrJobsList.size() - 1)));
       dataset.addProperty("score", jobPerfScore);
       dataset.add("stagescores", stageScores);
 
       datasets.add(dataset);
     }
 
-    return ok(new Gson().toJson(datasets));
+    JsonArray sortedDatasets = Utils.sortJsonArray(datasets);
+
+    return ok(new Gson().toJson(sortedDatasets));
   }
 
   /**
@@ -1330,7 +1336,7 @@ public class Application extends Controller {
 
       // Execution record
       JsonObject dataset = new JsonObject();
-      dataset.addProperty("flowtime", mrJobsList.get(mrJobsList.size() - 1).finishTime);
+      dataset.addProperty("flowtime", Utils.getFlowTime(mrJobsList.get(mrJobsList.size() - 1)));
       dataset.addProperty("runtime", Utils.getTotalRuntime(mrJobsList));
       dataset.addProperty("waittime", Utils.getTotalWaittime(mrJobsList));
       dataset.addProperty("resourceused", totalMemoryUsed);
@@ -1340,7 +1346,9 @@ public class Application extends Controller {
       datasets.add(dataset);
     }
 
-    return ok(new Gson().toJson(datasets));
+    JsonArray sortedDatasets = Utils.sortJsonArray(datasets);
+
+    return ok(new Gson().toJson(sortedDatasets));
   }
 
   /**
@@ -1480,7 +1488,7 @@ public class Application extends Controller {
 
       // Execution record
       JsonObject dataset = new JsonObject();
-      dataset.addProperty("flowtime", mrJobsList.get(mrJobsList.size() - 1).finishTime);
+      dataset.addProperty("flowtime", Utils.getFlowTime(mrJobsList.get(mrJobsList.size() - 1)));
       dataset.addProperty("runtime", totalFlowRuntime);
       dataset.addProperty("waittime", totalFlowDelay);
       dataset.addProperty("resourceused", totalFlowMemoryUsed);
@@ -1490,7 +1498,9 @@ public class Application extends Controller {
       datasets.add(dataset);
     }
 
-    return ok(new Gson().toJson(datasets));
+    JsonArray sortedDatasets = Utils.sortJsonArray(datasets);
+
+    return ok(new Gson().toJson(sortedDatasets));
   }
 
   /**


### PR DESCRIPTION
This change aims at providing a greater flexibility in the way the Flow History and Job History views are displayed. More specifically, it allows to customize the flowtime value (displayed under the _Flow Executions_ column) with a behaviour specific to each scheduler. 
By default, the old behaviour is kept (i.e. filling the flowtime with the job finish time), however, this is now possible to specify, in the scheduler configuration, that this field should be replaced by another one, with a specific formatting.

Concretely, this use case arose when integrating our internal scheduler to Dr.Elephant. Our scheduler is based on the notion of time series, where the _flowExecId_ value (coming from the scheduler) corresponds to the functional date (i.e. the date corresponding to the data partition that the job is processing. Most of the time, this corresponds to specific hours of data). Consequently, we are more interested by monitoring our jobs and their evolution according to this value than to the map reduce finish time, as shown on the example below : 
<img width="204" alt="capture d ecran 2017-07-13 a 15 27 59" src="https://user-images.githubusercontent.com/9437790/28168596-e704927e-67df-11e7-8a1b-e917af3984da.png">

This newly behaviour can be activated by simply providing the 2 following parameters in the scheduler configuration : 
```
<params>
    <flowtimefield>flowExecId</flowtimefield>
    <flowtimetype>yyyy-MM-dd'T'HH:mm:ss</flowtimetype>
</params>
```

where **flowtimefield** corresponds to the new flowtime value, and **flowtimetype** to the formatting that should be applied to this field.

This is handled through 2 new methods in _Utils.java_, which could be further expanded later on with other use case. 
Note that this also add the possibility to expand the sorting of the array so that it could be customized depending on the value used to fill the flowtime. For example, if one would like to replace the _flowtime_ value by the  _flowExecId_ which has the following format : execId_rundate, it is possible to modify the _sortJsonArray_ method so that if this specific format is encountered, then the ordering is done in one particular way.