### PR TITLE
[WIP][HDP-6846] First go at implementing data retention enforcement.

### DIFF
--- a/app-conf/GeneralConf.xml
+++ b/app-conf/GeneralConf.xml
@@ -45,4 +45,19 @@
     <name>drelephant.analysis.fetch.initial.windowMillis</name>
     <value>3600000</value>
   </property> -->
+  <property>
+    <name>drelephant.analysis.retention.period</name>
+    <value>30</value>
+    <description>Number of days of analysis to be kept in the database</description>
+  </property>
+  <property>
+    <name>drelephant.analysis.purge.batch.size</name>
+    <value>10000</value>
+    <description>Batch size of purge operation</description>
+  </property>
+  <property>
+    <name>drelephant.analysis.purge.operation.interval</name>
+    <value>60000</value>
+    <description>Interval between purge operations in milliseconds</description>
+  </property>
 </configuration>

--- a/app/models/AppResult.java
+++ b/app/models/AppResult.java
@@ -16,12 +16,16 @@
 
 package models;
 
+import com.avaje.ebean.Ebean;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.linkedin.drelephant.analysis.Severity;
 
 import com.linkedin.drelephant.util.Utils;
 import java.util.Date;
+
+import org.joda.time.DateTime;
 import play.db.ebean.Model;
+import play.db.ebean.Transactional;
 
 import java.util.List;
 
@@ -164,4 +168,15 @@ public class AppResult extends Model {
   public List<AppHeuristicResult> yarnAppHeuristicResults;
 
   public static Finder<String, AppResult> find = new Finder<String, AppResult>(String.class, AppResult.class);
+
+  @Transactional
+  public static int deleteOlderThan(int days, int batchSize) {
+    List<AppResult> toDelete =
+            find.where().lt("finishTime", DateTime.now().minusDays(days).getMillis()).setMaxRows(batchSize).findList();
+    for (AppResult appResult : toDelete) {
+      Ebean.delete(appResult);
+    }
+
+    return toDelete.size();
+  }
 }


### PR DESCRIPTION
I have the following questions:

1 - 
- what about testability? I had in mind to do the following tests:
--> config value: valid/invalid; invalid config = no purge
--> config value + older rows -> rows deleted
--> config value + newer rows -> no deletion
--> num rows > batch size -> row deletion in multiple iterations
however, how can I really test ElephantRunner? does the logic belong elsewhere? moving it risks inconsistency

2 - 
- failed fetches are given a retry interval before stopping for THAT attempt (i.e., fetch every minute, but retry 3 times before going back after a minute). is this retry necessary for purge? seems like overkill but thought i would ask.

3 - 
- number of jobs skipped or analyzed is exposed as a rest api queryable metric. for the purge to be "feature-complete," does the number of jobs purged need to be exposed as well?

4 - 
- should fetch and purge settings be refactored into separate, proper objects, analogous to scheduler settings, etc.? 

5 - any other feedback...