### PR TITLE
Fix bug with default block size when using viewfs

### DIFF
--- a/app/com/linkedin/drelephant/analysis/HDFSContext.java
+++ b/app/com/linkedin/drelephant/analysis/HDFSContext.java
@@ -40,6 +40,9 @@ public final class HDFSContext {
 
   /**
    * Captures the HDFS Block Size
+   * This is the default block size. Even if applications may override it, it is not the most common case,
+   * and it will just raise a false negative in file limits.
+   * Same about the blocksizes of different file systems. We decide to choose the lowest one.
    */
   public static void load() {
     try {

--- a/app/com/linkedin/drelephant/util/SparkUtils.scala
+++ b/app/com/linkedin/drelephant/util/SparkUtils.scala
@@ -68,6 +68,13 @@ trait SparkUtils {
           (FileSystem.get(uri, hadoopConfiguration), new Path(uri.getPath))
         case Some(uri) if uri.getScheme == "hdfs" =>
           (FileSystem.get(new URI(s"webhdfs://${uri.getHost}:${DFS_HTTP_PORT}${uri.getPath}"), hadoopConfiguration), new Path(uri.getPath))
+        case Some(uri) if uri.getScheme == "viewfs" =>
+          val fs = FileSystem.get(uri, hadoopConfiguration)
+          val path = new Path(uri)
+          //In case of federation this will resolve to the correct hdfs
+          val realUri = fs.resolvePath(path).toUri
+          val webfsUri = new URI(s"webhdfs://${realUri.getHost}:${DFS_HTTP_PORT}${realUri.getPath}")
+          (FileSystem.get(webfsUri, hadoopConfiguration), new Path(realUri.getPath))
         case Some(uri) =>
           val nameNodeAddress
           = hadoopUtils.findHaNameNodeAddress(hadoopConfiguration)


### PR DESCRIPTION
Adaptations to support viewfs and federation :

  - When using viewfs it is not possible to easily find the namenode master for a given path. Thus when scheme is viewfs, I resolve path with FileSystem and reconstruct a webhdfs uri. For this, I didn't know how to add a test with specific set of config files.
  - To define the HDFS blocksize (that is used only to define file size limits), there is no easy way to process per service block size. I make the assumptiom that we would like to consider the lowest blocksize of all filesystems. Most of the time it will be the same for all filesystems. I could have use to pick the first one or find a min recursively. I went to the latter but it is arguable.