### PR TITLE
Use spark 2.1 and spark SQL

### DIFF
--- a/app/org/apache/spark/storage/StorageStatusTrackingListener.scala
+++ b/app/org/apache/spark/storage/StorageStatusTrackingListener.scala
@@ -77,7 +77,7 @@ class StorageStatusTrackingListener extends SparkListener {
       val info = taskEnd.taskInfo
       val metrics = taskEnd.taskMetrics
       if (info != null && metrics != null) {
-        val updatedBlocks = metrics.updatedBlocks.getOrElse(Seq[(BlockId, BlockStatus)]())
+        val updatedBlocks = metrics.updatedBlockStatuses
         if (updatedBlocks.length > 0) {
           updateStorageStatus(info.executorId, updatedBlocks)
         }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
     hadoopVersion = System.getProperties.getProperty(HADOOP_VERSION)
   }
 
-  var sparkVersion = "1.4.0"
+  var sparkVersion = "2.1.0"
   if (System.getProperties.getProperty(SPARK_VERSION) != null) {
     sparkVersion = System.getProperties.getProperty(SPARK_VERSION)
   }
@@ -58,6 +58,13 @@ object Dependencies {
       ExclusionRule(organization = "net.razorvine")
       )
   }
+
+  val sparkSql = "org.apache.spark" % "spark-sql_2.10" % sparkVersion excludeAll(
+    ExclusionRule(organization = "com.typesafe.akka"),
+    ExclusionRule(organization = "org.apache.avro"),
+    ExclusionRule(organization = "org.apache.hadoop"),
+    ExclusionRule(organization = "net.razorvine")
+  )
 
   // Dependency coordinates
   var requiredDep = Seq(
@@ -94,7 +101,7 @@ object Dependencies {
     "org.apache.httpcomponents" % "httpclient" % "4.5.2",
     "org.scalatest" %% "scalatest" % "3.0.0" % Test
 
-  ) :+ sparkExclusion
+  ) :+ sparkExclusion :+ sparkSql
 
   var dependencies = Seq(javaJdbc, javaEbean, cache)
   dependencies ++= requiredDep

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # the License.
 #
 
-sbt.version=0.13.2
+sbt.version=0.13.9


### PR DESCRIPTION
Since we use Spark 2.1, we need a full rebuild of the project with spark 2.1

Changes are mostly due to new version of EventLog listeners

We also need to upgrade to sbt 0.13.9 for an obscure build error

This change is compatible with Spark 1.4> spark logs 