### PR TITLE
Add serialization heuristics

### DIFF
--- a/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
@@ -235,17 +235,17 @@ object StagesHeuristic {
       metrics <- taskValue.taskMetrics
     } yield (taskValue, metrics)
 
-    lazy val taskSerializationTimeProportionAndSeverities: ProportionSeverities[(TaskData, TaskMetrics)] =
-      ProportionSeverities.apply[(TaskData, TaskMetrics)](
+    lazy val taskSerializationTimeProportionAndSeverities =
+      ProportionSeverities(
         taskMetrics,
-        elem => elem._2.resultSerializationTime / elem._2.executorRunTime.toFloat,
+        (elem: (TaskData, TaskMetrics)) => elem._2.resultSerializationTime / elem._2.executorRunTime.toFloat,
         taskSerializationTimeProportionSeverityThresholds
       )
 
-    lazy val taskDeserializationTimeProportionAndSeverities: ProportionSeverities[(TaskData, TaskMetrics)] =
-      ProportionSeverities.apply[(TaskData, TaskMetrics)](
+    lazy val taskDeserializationTimeProportionAndSeverities =
+      ProportionSeverities(
         taskMetrics,
-        elem => elem._2.executorDeserializeTime / elem._2.executorRunTime.toFloat,
+        (elem: (TaskData, TaskMetrics))=> elem._2.executorDeserializeTime / elem._2.executorRunTime.toFloat,
         taskDeserializationTimeProportionSeverityThresholds
       )
 

--- a/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
+++ b/app/com/linkedin/drelephant/spark/heuristics/StagesHeuristic.scala
@@ -286,10 +286,10 @@ case class ProportionSeverities[A](data: Seq[(A, Float, Severity)]) {
 }
 
 object ProportionSeverities {
-  def apply[A](metrics: Seq[A], ProportionExtractor: A => Float, thresholds: SeverityThresholds): ProportionSeverities[A] =
+  def apply[A](metrics: Seq[A], proportionExtractor: A => Float, thresholds: SeverityThresholds): ProportionSeverities[A] =
     new ProportionSeverities[A](
       metrics.map { elem =>
-        val proportion = ProportionExtractor(elem)
+        val proportion = proportionExtractor(elem)
         val severity = thresholds.severityOf(proportion)
         (elem, proportion, severity)
       }

--- a/app/views/help/spark/helpStagesHeuristic.scala.html
+++ b/app/views/help/spark/helpStagesHeuristic.scala.html
@@ -18,3 +18,13 @@ each stage, and long average executor runtimes for each stage.</p>
 
 <p>Stage/task failures can occur for a number of reasons, so it is
 recommended to look at the YARN application error logs.</p>
+
+<h5><strong>1. Long serialization/deserialization time</strong></h5>
+<p>
+    Long serialization/deserialization time can be caused by many reasons, including:
+<ul>
+    <li>using a inefficient serializer (which should also get signalled by ConfigurationHeuristics)</li>
+    <li>serialization/deserialization of unnecessary data</li>
+    <li>inefficient shuffle algorithm</li>
+</ul>
+</p>


### PR DESCRIPTION
Includes:
* Logic for extracting proportion of executor runtime spent on serialization/deserialization
* Unit tests
* Help page on dashboard, which explains the meaning of heuristics